### PR TITLE
pr: implement a good-enough markdown previewer

### DIFF
--- a/app/WeblAdmin/WeblAdmin.xcodeproj/project.pbxproj
+++ b/app/WeblAdmin/WeblAdmin.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		535BBE0627C7595D00920283 /* WebPostPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535BBE0527C7595D00920283 /* WebPostPreview.swift */; };
 		535BBE0A27C75E1B00920283 /* style.css in Resources */ = {isa = PBXBuildFile; fileRef = 535BBE0927C75E1B00920283 /* style.css */; };
 		535BBE0D27C762E100920283 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = 535BBE0C27C762E100920283 /* Markdown */; };
+		535BBE0F27C764F100920283 /* HtmlEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535BBE0E27C764F100920283 /* HtmlEncoder.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -37,6 +38,7 @@
 		5333A27827C313780064FF44 /* DateView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateView.swift; sourceTree = "<group>"; };
 		535BBE0527C7595D00920283 /* WebPostPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPostPreview.swift; sourceTree = "<group>"; };
 		535BBE0927C75E1B00920283 /* style.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = style.css; sourceTree = "<group>"; };
+		535BBE0E27C764F100920283 /* HtmlEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HtmlEncoder.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -94,6 +96,7 @@
 		5333A26C27C2F3D10064FF44 /* System */ = {
 			isa = PBXGroup;
 			children = (
+				535BBE0E27C764F100920283 /* HtmlEncoder.swift */,
 				5333A26D27C2F3EE0064FF44 /* WebClient.swift */,
 			);
 			path = System;
@@ -213,6 +216,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				53105D2527C3722D0038204F /* PostSourceViewer.swift in Sources */,
+				535BBE0F27C764F100920283 /* HtmlEncoder.swift in Sources */,
 				5333A27627C30F470064FF44 /* PostListViewState.swift in Sources */,
 				5333A26027C2F3A80064FF44 /* ContentView.swift in Sources */,
 				5333A27927C313780064FF44 /* DateView.swift in Sources */,

--- a/app/WeblAdmin/WeblAdmin.xcodeproj/project.pbxproj
+++ b/app/WeblAdmin/WeblAdmin.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		5333A27927C313780064FF44 /* DateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5333A27827C313780064FF44 /* DateView.swift */; };
 		535BBE0627C7595D00920283 /* WebPostPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535BBE0527C7595D00920283 /* WebPostPreview.swift */; };
 		535BBE0A27C75E1B00920283 /* style.css in Resources */ = {isa = PBXBuildFile; fileRef = 535BBE0927C75E1B00920283 /* style.css */; };
+		535BBE0D27C762E100920283 /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = 535BBE0C27C762E100920283 /* Markdown */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -43,6 +44,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				535BBE0D27C762E100920283 /* Markdown in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -149,6 +151,9 @@
 			dependencies = (
 			);
 			name = WeblAdmin;
+			packageProductDependencies = (
+				535BBE0C27C762E100920283 /* Markdown */,
+			);
 			productName = WeblAdmin;
 			productReference = 5333A25A27C2F3A80064FF44 /* WeblAdmin.app */;
 			productType = "com.apple.product-type.application";
@@ -177,6 +182,9 @@
 				Base,
 			);
 			mainGroup = 5333A25127C2F3A80064FF44;
+			packageReferences = (
+				535BBE0B27C762E100920283 /* XCRemoteSwiftPackageReference "swift-markdown" */,
+			);
 			productRefGroup = 5333A25B27C2F3A80064FF44 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -408,6 +416,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		535BBE0B27C762E100920283 /* XCRemoteSwiftPackageReference "swift-markdown" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-markdown.git";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		535BBE0C27C762E100920283 /* Markdown */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 535BBE0B27C762E100920283 /* XCRemoteSwiftPackageReference "swift-markdown" */;
+			productName = Markdown;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 5333A25227C2F3A80064FF44 /* Project object */;
 }

--- a/app/WeblAdmin/WeblAdmin.xcodeproj/project.pbxproj
+++ b/app/WeblAdmin/WeblAdmin.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		5333A27427C30F3B0064FF44 /* PostListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5333A27327C30F3B0064FF44 /* PostListView.swift */; };
 		5333A27627C30F470064FF44 /* PostListViewState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5333A27527C30F470064FF44 /* PostListViewState.swift */; };
 		5333A27927C313780064FF44 /* DateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5333A27827C313780064FF44 /* DateView.swift */; };
+		535BBE0627C7595D00920283 /* WebPostPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535BBE0527C7595D00920283 /* WebPostPreview.swift */; };
+		535BBE0A27C75E1B00920283 /* style.css in Resources */ = {isa = PBXBuildFile; fileRef = 535BBE0927C75E1B00920283 /* style.css */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +34,8 @@
 		5333A27327C30F3B0064FF44 /* PostListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListView.swift; sourceTree = "<group>"; };
 		5333A27527C30F470064FF44 /* PostListViewState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListViewState.swift; sourceTree = "<group>"; };
 		5333A27827C313780064FF44 /* DateView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DateView.swift; sourceTree = "<group>"; };
+		535BBE0527C7595D00920283 /* WebPostPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPostPreview.swift; sourceTree = "<group>"; };
+		535BBE0927C75E1B00920283 /* style.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = style.css; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -104,9 +108,11 @@
 		5333A27227C30F270064FF44 /* Posts */ = {
 			isa = PBXGroup;
 			children = (
+				535BBE0827C75DFA00920283 /* Resources */,
 				5333A27327C30F3B0064FF44 /* PostListView.swift */,
 				5333A27527C30F470064FF44 /* PostListViewState.swift */,
 				53105D2427C3722D0038204F /* PostSourceViewer.swift */,
+				535BBE0527C7595D00920283 /* WebPostPreview.swift */,
 			);
 			path = Posts;
 			sourceTree = "<group>";
@@ -117,6 +123,14 @@
 				5333A27827C313780064FF44 /* DateView.swift */,
 			);
 			path = Common;
+			sourceTree = "<group>";
+		};
+		535BBE0827C75DFA00920283 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				535BBE0927C75E1B00920283 /* style.css */,
+			);
+			path = Resources;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -178,6 +192,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5333A26527C2F3A90064FF44 /* Preview Assets.xcassets in Resources */,
+				535BBE0A27C75E1B00920283 /* style.css in Resources */,
 				5333A26227C2F3A90064FF44 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -196,6 +211,7 @@
 				5333A25E27C2F3A80064FF44 /* WeblAdminApp.swift in Sources */,
 				5333A27127C2F44B0064FF44 /* AccountPreferences.swift in Sources */,
 				5333A26E27C2F3EE0064FF44 /* WebClient.swift in Sources */,
+				535BBE0627C7595D00920283 /* WebPostPreview.swift in Sources */,
 				5333A27427C30F3B0064FF44 /* PostListView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/app/WeblAdmin/WeblAdmin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/app/WeblAdmin/WeblAdmin.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,23 @@
+{
+  "pins" : [
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-cmark.git",
+      "state" : {
+        "branch" : "gfm",
+        "revision" : "7fc530e5f12432db9768326ff74dc46de72a24e2"
+      }
+    },
+    {
+      "identity" : "swift-markdown",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-markdown.git",
+      "state" : {
+        "branch" : "main",
+        "revision" : "a5b00f49b2ac5e2ef2d0bf5dbdf33e6ea0b200a5"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/app/WeblAdmin/WeblAdmin/Posts/PostSourceViewer.swift
+++ b/app/WeblAdmin/WeblAdmin/Posts/PostSourceViewer.swift
@@ -30,11 +30,17 @@ struct PostSourceViewer: View {
             .padding([.horizontal, .top])
 
             VStack {
-                WebPostPreview(document: "<p>\(post.text)</p>")
+                WebPostPreview(document: post.text.markdownToHtml)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .padding(.leading, 10)
         }
         .background(Color(nsColor: .textBackgroundColor))
+    }
+}
+
+fileprivate extension String {
+    var markdownToHtml: String {
+        HTMLEncoder(self).html()
     }
 }

--- a/app/WeblAdmin/WeblAdmin/Posts/PostSourceViewer.swift
+++ b/app/WeblAdmin/WeblAdmin/Posts/PostSourceViewer.swift
@@ -13,33 +13,28 @@ struct PostSourceViewer: View {
 
 
     var body: some View {
-        VStack(spacing: 10) {
-            HStack {
-                Text(post.slugline)
-                    .font(.headline)
+        VStack {
+            VStack(spacing: 10) {
+                HStack {
+                    Text(post.slugline)
+                        .font(.headline)
 
-                Spacer()
-                DateView(date: post.datePublished, format: .dateTimeNameLong)
-                    .font(.subheadline)
-            }
-            .lineLimit(1)
-
-            Divider()
-            //.overlay(Divider(), alignment: .bottom)
-
-            ScrollView {
-                VStack {
-
-                    Text(post.text)
-                        .font(.body.monospaced())
-                        .foregroundColor(.indigo)
-                        .lineSpacing(5)
                     Spacer()
+                    DateView(date: post.datePublished, format: .dateTimeNameLong)
+                        .font(.subheadline)
                 }
-            }
+                .lineLimit(1)
 
+                Divider()
+            }
+            .padding([.horizontal, .top])
+
+            VStack {
+                WebPostPreview(document: "<p>\(post.text)</p>")
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(.leading, 10)
         }
-        .padding()
         .background(Color(nsColor: .textBackgroundColor))
     }
 }

--- a/app/WeblAdmin/WeblAdmin/Posts/Resources/style.css
+++ b/app/WeblAdmin/WeblAdmin/Posts/Resources/style.css
@@ -1,5 +1,32 @@
+/*
+ font: -apple-system-body
+ font: -apple-system-headline
+ font: -apple-system-subheadline
+ font: -apple-system-caption1
+ font: -apple-system-caption2
+ font: -apple-system-footnote
+ font: -apple-system-short-body
+ font: -apple-system-short-headline
+ font: -apple-system-short-subheadline
+ font: -apple-system-short-caption1
+ font: -apple-system-short-footnote
+ font: -apple-system-tall-body
+ */
+
 :root {
     color-scheme: light dark;
     font: -apple-system-body;
 }
 
+code {
+    color: firebrick;
+}
+
+pre {
+    color: #777;
+    margin-left: 5px;
+}
+
+p {
+    line-height: 1.4;
+}

--- a/app/WeblAdmin/WeblAdmin/Posts/Resources/style.css
+++ b/app/WeblAdmin/WeblAdmin/Posts/Resources/style.css
@@ -1,0 +1,5 @@
+:root {
+    color-scheme: light dark;
+    font: -apple-system-body;
+}
+

--- a/app/WeblAdmin/WeblAdmin/Posts/WebPostPreview.swift
+++ b/app/WeblAdmin/WeblAdmin/Posts/WebPostPreview.swift
@@ -1,0 +1,36 @@
+//
+//  WebPostPreview.swift
+//  WeblAdmin
+//
+//  Created by Keith Irwin on 2/23/22.
+//
+
+import SwiftUI
+import WebKit
+
+struct WebPostPreview: NSViewRepresentable {
+    var document: String
+
+    func makeNSView(context: Context) -> WKWebView {
+        let view = WKWebView()
+        view.setValue(false, forKey: "drawsBackground")
+        return view
+    }
+
+    func updateNSView(_ view: WKWebView, context: Context) {
+
+        if let resourceDir = Bundle.main.resourcePath {
+            let dir = URL(fileURLWithPath: resourceDir + "/", isDirectory: true)
+            let doc = wrap(document)
+            view.loadHTMLString(doc, baseURL: dir)
+        } else {
+            view.loadHTMLString("<p>Unable to load document.</p>", baseURL: nil)
+        }
+    }
+
+    private func wrap(_ doc: String) -> String {
+        let head = #"<html><head><link href="style.css" type="text/css" rel="stylesheet"/></head><body>"#
+        let foot = #"</body></html>"#
+        return "\(head)\(doc)\(foot)"
+    }
+}

--- a/app/WeblAdmin/WeblAdmin/Posts/WebPostPreview.swift
+++ b/app/WeblAdmin/WeblAdmin/Posts/WebPostPreview.swift
@@ -9,11 +9,13 @@ import SwiftUI
 import WebKit
 
 struct WebPostPreview: NSViewRepresentable {
+
     var document: String
 
     func makeNSView(context: Context) -> WKWebView {
         let view = WKWebView()
         view.setValue(false, forKey: "drawsBackground")
+        view.navigationDelegate = context.coordinator
         return view
     }
 
@@ -21,16 +23,36 @@ struct WebPostPreview: NSViewRepresentable {
 
         if let resourceDir = Bundle.main.resourcePath {
             let dir = URL(fileURLWithPath: resourceDir + "/", isDirectory: true)
-            let doc = wrap(document)
-            view.loadHTMLString(doc, baseURL: dir)
+            view.loadHTMLString(document, baseURL: dir)
         } else {
             view.loadHTMLString("<p>Unable to load document.</p>", baseURL: nil)
         }
     }
 
-    private func wrap(_ doc: String) -> String {
-        let head = #"<html><head><link href="style.css" type="text/css" rel="stylesheet"/></head><body>"#
-        let foot = #"</body></html>"#
-        return "\(head)\(doc)\(foot)"
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    class Coordinator: NSObject, WKNavigationDelegate {
+
+        private var parent: WebPostPreview
+
+        init(_ parent: WebPostPreview) {
+            self.parent = parent
+        }
+
+        func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
+                     decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+            // Only allow the user to open links in their default browser, rather than
+            // within the webview itself.
+            if let url = navigationAction.request.url {
+                if url.absoluteString.hasPrefix("http") {
+                    NSWorkspace.shared.open(url)
+                    decisionHandler(WKNavigationActionPolicy.cancel)
+                    return
+                }
+            }
+            decisionHandler(WKNavigationActionPolicy.allow)
+        }
     }
 }

--- a/app/WeblAdmin/WeblAdmin/System/HtmlEncoder.swift
+++ b/app/WeblAdmin/WeblAdmin/System/HtmlEncoder.swift
@@ -1,0 +1,131 @@
+//
+//  HtmlEncoder.swift
+//  WeblAdmin
+//
+//  Created by Keith Irwin on 2/23/22.
+//
+
+import Foundation
+import Markdown
+
+final class HTMLEncoder {
+
+    var markdown: String
+
+    init(_ markdown: String) {
+        self.markdown = markdown
+    }
+
+    func html() -> String {
+        let doc = Document(parsing: markdown)
+        var decoder = MarkdownDecoder()
+        decoder.visit(doc)
+        return decoder.elements.joined(separator: "")
+    }
+}
+
+struct MarkdownDecoder: MarkupWalker {
+
+    var elements = [String]()
+
+    mutating func visitHeading(_ heading: Heading) -> () {
+        let tag = "h\(heading.level)"
+        elements.append("<\(tag)>")
+        descendInto(heading)
+        elements.append("</\(tag)>")
+    }
+
+    // BLOCKS
+
+    mutating func visitDocument(_ document: Document) -> () {
+        elements.append("<!doctype html>")
+        elements.append(#"<html><head><meta charset="UTF-8"><link href="style.css" type="text/css" rel="stylesheet"/></head><body>"#)
+        descendInto(document)
+        elements.append("</body></html>")
+    }
+    mutating func visitParagraph(_ paragraph: Paragraph) -> () {
+        elements.append("<p>")
+        descendInto(paragraph)
+        elements.append("</p>")
+    }
+
+    mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) -> () {
+        elements.append("<hr/>")
+    }
+
+    mutating func visitBlockQuote(_ blockQuote: BlockQuote) -> () {
+        elements.append("<blockquote>")
+        descendInto(blockQuote)
+        elements.append("</blockquote>")
+    }
+
+    // TEXT
+
+    mutating func visitText(_ text: Text) -> () {
+        elements.append(text.string)
+        descendInto(text)
+    }
+
+    // LINK
+
+    mutating func visitLink(_ link: Link) -> () {
+        let title = link.plainText
+        let href = link.destination ?? "#"
+        let link = #"<a title="\#(title)" href="\#(href)">\#(title)</a>"#
+        elements.append(link)
+    }
+
+    // STYLE
+
+    mutating func visitInlineCode(_ inlineCode: InlineCode) -> () {
+        elements.append("<code>\(inlineCode.code)</code>")
+    }
+
+    mutating func visitEmphasis(_ emphasis: Emphasis) -> () {
+        elements.append("<i>")
+        descendInto(emphasis)
+        elements.append("</i>")
+    }
+
+    mutating func visitStrong(_ strong: Strong) -> () {
+        elements.append("<b>")
+        descendInto(strong)
+        elements.append("</b>")
+    }
+
+    // CODE
+
+    mutating func visitCodeBlock(_ codeBlock: CodeBlock) -> () {
+        elements.append("<pre>")
+        elements.append(codeBlock.code)
+        //descendInto(codeBlock)
+        elements.append("</pre>")
+    }
+
+    mutating func visitInlineHTML(_ inlineHTML: InlineHTML) -> () {
+        elements.append(inlineHTML.rawHTML)
+    }
+
+    mutating func visitHTMLBlock(_ html: HTMLBlock) -> () {        
+        elements.append(html.rawHTML)
+    }
+
+//    mutating func defaultVisit(_ markup: Markup) -> () {
+//        print("DEFAULT VISIT: \(markup)")
+//        descendInto(markup)
+//    }
+
+    // LISTS
+
+    mutating func visitUnorderedList(_ unorderedList: UnorderedList) -> () {
+        elements.append("<ul>")
+        descendInto(unorderedList)
+        elements.append("</ul>")
+    }
+
+    mutating func visitListItem(_ listItem: ListItem) -> () {
+        elements.append("<li>")
+        descendInto(listItem)
+        elements.append("</li>")
+    }
+}


### PR DESCRIPTION
The change:

* closes #14 
* closes #15 
* closes #16 

The HTML covers current blog posts, but is easily extendable. The web previewer is smart enough to require links to be opened in the default browser, not the component itself.